### PR TITLE
Remove Gradle Wrapper Validation build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,6 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v4
 
-      # Validate wrapper
-#      - name: Gradle Wrapper Validation
-#        uses: gradle/actions/wrapper-validation@v3
-
       # Set up Java environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
It's flaky as a standalone action and the functionality is already covered by [the `setup-gradle` action](https://github.com/gradle/actions).